### PR TITLE
Remove double series from metadata

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,5 +11,3 @@ series:
 requires:
   database:
     interface: mysql
-series:
-  - bionic


### PR DESCRIPTION
Removes second definition of series field in metadata.